### PR TITLE
bugfix

### DIFF
--- a/src/getset.ts
+++ b/src/getset.ts
@@ -172,7 +172,8 @@ export function generateClassesList(type: EType): IClass[] {
                                         break;
                                     }
                                 }
-                            } else if (type == EType.SETTER || type == EType.BOTH) {
+                            }
+                            if (type == EType.SETTER || type == EType.BOTH) {
                                 for (let j = 0; j < _class.setters.length; j++) {
                                     if (_class.vars[i].figure.toLowerCase() === _class.setters[j].toLowerCase()) {
                                         _class.vars.splice(i, 1);


### PR DESCRIPTION
jj@GROSSER-DELL:/mnt/c/Users/Joachim/Desktop/typescript.telegram-bot-api$ npx tsc ads.ts
ads.ts:175:64 - error TS2367: This condition will always return 'false' since the types 'EType.CONSTRUCTOR' and 'EType.BOTH' have no overlap.

175                             } else if (type == EType.SETTER || type == EType.BOTH) {
                                                                   ~~~~~~~~~~~~~~~~~~


Found 1 error.